### PR TITLE
Actions - Publish addons to releases

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -19,6 +19,7 @@ jobs:
                   artifacts: "*.mcaddon"
                   bodyFile: "release.md"
                   token: ${{ secrets.GITHUB_TOKEN }}
-                  tag: "R${{ github.run_number }}"
-                  name: "Release #${{ github.run_number }}"
+                  tag: "download"
+                  name: "Downloads"
                   replacesArtifacts: true
+                  allowUpdates: true

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,29 +1,24 @@
-
 name: 'Package Add-Ons'
 
 on:
     push:
         branches:
             - main
-
 jobs:
     release:
-        name: 📦 package
+        name: Release packages
         runs-on: ubuntu-latest
         steps:
-            - name: 📚 checkout
+            - name: Checkout
               uses: actions/checkout@v2.1.1
-              env:
-                  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-            - name: 🟢 node
-              uses: actions/setup-node@v1.4.2
-              env:
-                  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+            - name: Bedrock Addon Packager
+              uses: Fabrimat/addon-packager-action@v0.1
+            - name: Publish release
+              uses: ncipollo/release-action@v1
               with:
-                  node-version: 12
-                  registry-url: https://registry.npmjs.org
-            - name: 📦 package
-              run: npm publish --access public
-              env:
-                  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-                  NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
+                  artifacts: "*.mcaddon"
+                  bodyFile: "release.md"
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  tag: "R${{ github.run_number }}"
+                  name: "Release #${{ github.run_number }}"
+                  replacesArtifacts: true

--- a/release.md
+++ b/release.md
@@ -1,0 +1,1 @@
+This release was automatically generated.


### PR DESCRIPTION
Closes #3 
`release.md` is the release body.
The workflow can be done in more different ways as discussed [on the Discord](https://discord.com/channels/494194063730278411/713856400631267369/1029085996194738207).
Example of how it works [here](https://github.com/Fabrimat/wiki-addon/releases/tag/Downloads).
It will create only one release and updates it.